### PR TITLE
WP-29311 python upgrade

### DIFF
--- a/netsuitesdk/internal/client.py
+++ b/netsuitesdk/internal/client.py
@@ -33,6 +33,9 @@ class NetSuiteClient:
     """The Netsuite client class providing access to the Netsuite
     SOAP/WSDL web service"""
 
+    # update the url endpoint to newer version since newer Zeep cannot support old ones
+    # but like it or not SOAP is being deprecated soon, we need to upgrade to their REST API
+    # https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N3418621.html
     WSDL_URL_TEMPLATE = 'https://{account}.suitetalk.api.netsuite.com/wsdl/v2024_1_0/netsuite.wsdl'
     DATACENTER_URL_TEMPLATE = 'https://{account}.suitetalk.api.netsuite.com/services/NetSuitePort_2024_1'
 

--- a/netsuitesdk/internal/client.py
+++ b/netsuitesdk/internal/client.py
@@ -33,8 +33,8 @@ class NetSuiteClient:
     """The Netsuite client class providing access to the Netsuite
     SOAP/WSDL web service"""
 
-    WSDL_URL_TEMPLATE = 'https://{account}.suitetalk.api.netsuite.com/wsdl/v2019_1_0/netsuite.wsdl'
-    DATACENTER_URL_TEMPLATE = 'https://{account}.suitetalk.api.netsuite.com/services/NetSuitePort_2019_1'
+    WSDL_URL_TEMPLATE = 'https://{account}.suitetalk.api.netsuite.com/wsdl/v2024_1_0/netsuite.wsdl'
+    DATACENTER_URL_TEMPLATE = 'https://{account}.suitetalk.api.netsuite.com/services/NetSuitePort_2024_1'
 
     _search_preferences = None
     _passport = None
@@ -82,7 +82,7 @@ class NetSuiteClient:
 
         # default service points to wrong data center. need to create a new service proxy and replace the default one
         self._service_proxy = self._client.create_service(
-            '{urn:platform_2019_1.webservices.netsuite.com}NetSuiteBinding', self._datacenter_url)
+            '{urn:platform_2024_1.webservices.netsuite.com}NetSuiteBinding', self._datacenter_url)
 
         # Parse all complex types specified in :const:`~netsuitesdk.netsuite_types.COMPLEX_TYPES`
         # and store them as attributes of this instance. Same for simple types.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='netsuitesdk',
-    version='2.7.6',
+    version='3.0.0',
     author='Siva Narayanan',
     author_email='siva@fyle.in',
     description='Python SDK for accessing the NetSuite SOAP webservice',


### PR DESCRIPTION
- old endpoints incompatible with new Zeep, which we need for Python 3.13